### PR TITLE
Fix macos test target and simplify build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -6,12 +6,51 @@ pub fn build(b: *std.Build) void {
 
     const target_os = target.result.os.tag;
 
+    // Resolve Windows library directory (used by module linking and DLL copy)
+    const win_arch_dir: ?[]const u8 = if (target_os == .windows) switch (target.result.cpu.arch) {
+        .x86_64 => "windows-x86_64",
+        .aarch64 => "windows-aarch64",
+        .x86 => "windows-x86",
+        else => @panic("Unsupported Windows architecture"),
+    } else null;
+
     // Create turf library
     const libturf = b.createModule(.{
         .root_source_file = b.path("src/turf.zig"),
         .target = target,
         .optimize = optimize,
     });
+
+    // Platform-specific dependencies on the library module.
+    // All consumers (exe, demo, tests) inherit these through module imports.
+    switch (target_os) {
+        .macos => {
+            libturf.addCSourceFile(.{
+                .file = b.path("src/platforms/macos/cocoa_bridge.m"),
+                .flags = &[_][]const u8{"-fobjc-arc"},
+            });
+            libturf.linkFramework("Cocoa", .{});
+            libturf.linkFramework("WebKit", .{});
+            libturf.link_libc = true;
+        },
+        .linux => {
+            libturf.linkSystemLibrary("gtk4", .{});
+            libturf.linkSystemLibrary("webkitgtk-6.0", .{});
+            libturf.linkSystemLibrary("javascriptcoregtk-6.0", .{});
+            libturf.link_libc = true;
+        },
+        .windows => {
+            libturf.addLibraryPath(b.path(b.fmt("src/platforms/windows/lib/{s}", .{win_arch_dir.?})));
+            libturf.linkSystemLibrary("WebView2Loader", .{});
+            libturf.linkSystemLibrary("ole32", .{});
+            libturf.linkSystemLibrary("shell32", .{});
+            libturf.linkSystemLibrary("shlwapi", .{});
+            libturf.linkSystemLibrary("user32", .{});
+            libturf.linkSystemLibrary("gdi32", .{});
+            libturf.link_libc = true;
+        },
+        else => @panic("Unsupported operating system"),
+    }
 
     const exe_mod = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
@@ -27,30 +66,6 @@ pub fn build(b: *std.Build) void {
         .root_module = libturf,
     });
 
-    // Platform-specific library linking
-    switch (target_os) {
-        .macos => {
-            // macOS deosn't need explicit linking for frameworks
-            // when building library
-        },
-        .linux => {
-            lib.linkSystemLibrary("gtk4");
-            lib.linkSystemLibrary("webkitgtk-6.0");
-            lib.linkSystemLibrary("javascriptcoregtk-6.0");
-            lib.linkLibC();
-        },
-        .windows => {
-            // Windows uses WebView2
-            // Libraries will be linked when building executable
-        },
-        else => {
-            std.debug.panic(
-                "Unsupported operating system: {s}\n",
-                .{@tagName(target_os)},
-            );
-        },
-    }
-
     b.installArtifact(lib);
 
     const exe = b.addExecutable(.{
@@ -58,58 +73,11 @@ pub fn build(b: *std.Build) void {
         .root_module = exe_mod,
     });
 
-    // Platform-specific executable configuration
-    switch (target_os) {
-        .macos => {
-            exe.linkFramework("Cocoa");
-            exe.linkFramework("WebKit");
-            exe.addCSourceFile(.{
-                .file = b.path("src/platforms/macos/cocoa_bridge.m"),
-                .flags = &[_][]const u8{"-fobjc-arc"},
-            });
-            exe.linkLibC();
-        },
-        .linux => {
-            exe.linkSystemLibrary("gtk4");
-            exe.linkSystemLibrary("webkitgtk-6.0");
-            exe.linkSystemLibrary("javascriptcoregtk-6.0");
-            exe.linkLibC();
-        },
-        .windows => {
-            // Get target architecture for WebView2Loader selection
-            const arch = target.result.cpu.arch;
-            const arch_dir = switch (arch) {
-                .x86_64 => "windows-x86_64",
-                .aarch64 => "windows-aarch64",
-                .x86 => "windows-x86",
-                else => @panic("Unsupported Windows architecture"),
-            };
-            
-            // Add WebView2Loader library
-            exe.addLibraryPath(b.path(b.fmt("src/platforms/windows/lib/{s}", .{arch_dir})));
-            exe.linkSystemLibrary("WebView2Loader");
-            exe.linkSystemLibrary("ole32");
-            exe.linkSystemLibrary("shell32");
-            exe.linkSystemLibrary("shlwapi");
-            exe.linkSystemLibrary("user32");
-            exe.linkSystemLibrary("gdi32");
-            exe.linkLibC();
-        },
-        else => {},
-    }
-
     b.installArtifact(exe);
-    
+
     // Copy WebView2Loader.dll to output directory on Windows
-    if (target_os == .windows) {
-        const arch = target.result.cpu.arch;
-        const arch_dir = switch (arch) {
-            .x86_64 => "windows-x86_64",
-            .aarch64 => "windows-aarch64",
-            .x86 => "windows-x86",
-            else => @panic("Unsupported Windows architecture"),
-        };
-        const dll_path = b.fmt("src/platforms/windows/lib/{s}/WebView2Loader.dll", .{arch_dir});
+    if (win_arch_dir) |dir| {
+        const dll_path = b.fmt("src/platforms/windows/lib/{s}/WebView2Loader.dll", .{dir});
         const install_dll = b.addInstallBinFile(b.path(dll_path), "WebView2Loader.dll");
         b.getInstallStep().dependOn(&install_dll.step);
     }
@@ -138,51 +106,7 @@ pub fn build(b: *std.Build) void {
 
     demo_mod.addImport("turf", libturf);
 
-    switch (target_os) {
-        .macos => {
-            demo.linkFramework("Cocoa");
-            demo.linkFramework("WebKit");
-            demo.addCSourceFile(.{
-                .file = b.path("src/platforms/macos/cocoa_bridge.m"),
-                .flags = &[_][]const u8{"-fobjc-arc"},
-            });
-            demo.linkLibC();
-        },
-        .linux => {
-            demo.linkSystemLibrary("gtk4");
-            demo.linkSystemLibrary("webkitgtk-6.0");
-            demo.linkSystemLibrary("javascriptcoregtk-6.0");
-            demo.linkLibC();
-        },
-        .windows => {
-            // Get target architecture for WebView2Loader selection
-            const arch = target.result.cpu.arch;
-            const arch_dir = switch (arch) {
-                .x86_64 => "windows-x86_64",
-                .aarch64 => "windows-aarch64",
-                .x86 => "windows-x86",
-                else => @panic("Unsupported Windows architecture"),
-            };
-            
-            // Add WebView2Loader library
-            demo.addLibraryPath(b.path(b.fmt("src/platforms/windows/lib/{s}", .{arch_dir})));
-            demo.linkSystemLibrary("WebView2Loader");
-            demo.linkSystemLibrary("ole32");
-            demo.linkSystemLibrary("shell32");
-            demo.linkSystemLibrary("shlwapi");
-            demo.linkSystemLibrary("user32");
-            demo.linkSystemLibrary("gdi32");
-            demo.linkLibC();
-        },
-        else => {},
-    }
-
     b.installArtifact(demo);
-    
-    // Copy WebView2Loader.dll for demo too
-    if (target_os == .windows) {
-        // DLL copy is already handled above for main exe
-    }
 
     const run_demo_cmd = b.addRunArtifact(demo);
     run_demo_cmd.step.dependOn(b.getInstallStep());
@@ -197,89 +121,8 @@ pub fn build(b: *std.Build) void {
         .root_module = libturf,
     });
 
-    // Platform specific test linking
-    switch (target_os) {
-        .macos => {
-            // TODO
-        },
-        .linux => {
-            lib_unit_tests.linkSystemLibrary("gtk4");
-            lib_unit_tests.linkSystemLibrary("webkitgtk-6.0");
-            lib_unit_tests.linkSystemLibrary("javascriptcoregtk-6.0");
-            lib_unit_tests.linkLibC();
-        },
-        .windows => {
-            // Windows test linking
-            lib_unit_tests.linkLibC();
-        },
-        else => {},
-    }
-
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
-
-    const exe_unit_tests = b.addTest(.{
-        .root_module = exe_mod,
-    });
-
-    // Platform-specific test linking for exe module
-    switch (target_os) {
-        .macos => {
-            // TODO
-        },
-        .linux => {
-            exe_unit_tests.linkSystemLibrary("gtk4");
-            exe_unit_tests.linkSystemLibrary("webkitgtk-6.0");
-            exe_unit_tests.linkSystemLibrary("javascriptcoregtk-6.0");
-            exe_unit_tests.linkLibC();
-        },
-        .windows => {
-            // Windows test linking
-            exe_unit_tests.linkLibC();
-        },
-        else => {},
-    }
-    const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
 
     const tests_step = b.step("test", "Run unit tests");
     tests_step.dependOn(&run_lib_unit_tests.step);
-    tests_step.dependOn(&run_exe_unit_tests.step);
 }
-
-// Add Cocoa and WebKit frameworks and compile Objective-C file
-//     exe.linkFramework("Cocoa");
-//     exe.linkFramework("WebKit");
-//     exe.addCSourceFile(.{
-//         .file = .{ .cwd_relative = "src/cocoa_bridge.m" },
-//         .flags = &[_][]const u8{"-fobjc-arc"},
-//     });
-//     exe.linkLibC();
-
-//     b.installArtifact(exe);
-
-//     const run_cmd = b.addRunArtifact(exe);
-
-//     run_cmd.step.dependOn(b.getInstallStep());
-
-//     if (b.args) |args| {
-//         run_cmd.addArgs(args);
-//     }
-
-//     const run_step = b.step("run", "Run the app");
-//     run_step.dependOn(&run_cmd.step);
-
-//     const lib_unit_tests = b.addTest(.{
-//         .root_module = libturf,
-//     });
-
-//     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
-
-//     const exe_unit_tests = b.addTest(.{
-//         .root_module = exe_mod,
-//     });
-
-//     const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
-
-//     const test_step = b.step("test", "Run unit tests");
-//     test_step.dependOn(&run_lib_unit_tests.step);
-//     test_step.dependOn(&run_exe_unit_tests.step);
-// }

--- a/src/turf.zig
+++ b/src/turf.zig
@@ -183,3 +183,7 @@ fn getAbsolutePath(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
 
 // Export platform-specific types
 pub const PlatformWindow = backend.PlatformWindow;
+
+test {
+    _ = backend;
+}


### PR DESCRIPTION
Key changes:
- Platform specific sources and linking moved to module level, inherited by all outputs
- Removed exe tests as superfluous
- Added test to turf that forces evaluation of backend
